### PR TITLE
Regenerate nested Ids on character make and duplicate functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Echo
+      - name: Dump GitHub context
+        id: github_context_step
+        run: echo '${{ toJSON(github) }}'
       # Checkout
       - name: Checkout
         uses: actions/checkout@v2
@@ -49,7 +53,7 @@ jobs:
   deploy-preview:
     needs: [build]
     runs-on: ubuntu-latest
-    if: github.repository == 'fariapp/fari-app' && github.ref != 'refs/heads/master'
+    if: github.repository == 'fariapp/fari-app' && github.ref != 'refs/heads/master' && secrets.NETLIFY_AUTH_TOKEN != ''
     environment:
       name: Preview
       url: https://${{github.run_id}}--fari.netlify.app
@@ -82,7 +86,7 @@ jobs:
   deploy-production:
     needs: [build]
     runs-on: ubuntu-latest
-    if: github.repository == 'fariapp/fari-app' && github.ref == 'refs/heads/master'
+    if: github.repository == 'fariapp/fari-app' && github.ref == 'refs/heads/master' && secrets.NETLIFY_AUTH_TOKEN != ''
     environment:
       name: Production
       url: https://fari.app

--- a/lib/domains/character/CharacterFactory.tsx
+++ b/lib/domains/character/CharacterFactory.tsx
@@ -124,7 +124,7 @@ export const CharacterFactory = {
                     return {
                       ...section,
                       id: Id.generate(),
-                      pages: section.blocks.map((block) => {
+                      blocks: section.blocks.map((block) => {
                         return {
                           ...block,
                           id: Id.generate(),

--- a/lib/domains/character/CharacterFactory.tsx
+++ b/lib/domains/character/CharacterFactory.tsx
@@ -37,6 +37,34 @@ export const CharacterFactory = {
     return {
       ...newCharacter,
       id: Id.generate(),
+            pages: newCharacter.pages.map((page) => {
+        return {
+          ...page,
+          id: Id.generate(),
+          rows: page.rows.map((row) => {
+            return {
+              ...row,
+              columns: row.columns.map((column) => {
+                return {
+                  ...column,
+                  sections: column.sections.map((section) => {
+                    return {
+                      ...section,
+                      id: Id.generate(),
+                      blocks: section.blocks.map((block) => {
+                        return {
+                          ...block,
+                          id: Id.generate(),
+                        };
+                      }),
+                    };
+                  }),
+                };
+              }),
+            };
+          }),
+        };
+      }),
       name: "",
       group: undefined,
       lastUpdated: getUnix(),

--- a/lib/domains/character/CharacterFactory.tsx
+++ b/lib/domains/character/CharacterFactory.tsx
@@ -78,12 +78,40 @@ export const CharacterFactory = {
       return character;
     }
   },
-  duplicate(c: ICharacter): ICharacter {
+  duplicate(character: ICharacter): ICharacter {
     return {
-      ...c,
+      ...character,
       id: Id.generate(),
+      pages: character.pages.map((page) => {
+        return {
+          ...page,
+          id: Id.generate(),
+          rows: page.rows.map((row) => {
+            return {
+              ...row,
+              columns: row.columns.map((column) => {
+                return {
+                  ...column,
+                  sections: column.sections.map((section) => {
+                    return {
+                      ...section,
+                      id: Id.generate(),
+                      pages: section.blocks.map((block) => {
+                        return {
+                          ...block,
+                          id: Id.generate(),
+                        };
+                      }),
+                    };
+                  }),
+                };
+              }),
+            };
+          }),
+        };
+      }),
       lastUpdated: getUnix(),
-      name: `${c?.name} Copy`,
+      name: `${character?.name} Copy`,
     };
   },
   makeATemplate(c: ICharacter): Omit<ICharacter, "id"> & { id: undefined } {


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->
**fix**
-

## 🌄 Context

<!-- Provide more context around why this pull request was created -->
Duplicated and made from template characters are currently retaining Ids from their original sheets which is causing collisions. 


## 🔒Checklist

- I tested my work on the feature environment

## 💅 Examples

<!-- Give examples or screenshots detailing the new behaviors of the application -->
