### PR TITLE
fix: vitest incorrectly returning an error b/c of Canvas

### DIFF
--- a/lib/hooks/useScene/__tests__/useSession.test.ts
+++ b/lib/hooks/useScene/__tests__/useSession.test.ts
@@ -69,6 +69,12 @@ describe("useSession", () => {
       // GIVEN
       const userId = "111";
 
+      // fixes an implementation problem in Canvas
+      // that renders it difficult to test
+      HTMLCanvasElement.prototype.getContext = () => {
+        // from: https://stackoverflow.com/questions/48828759/unit-test-raises-error-because-of-getcontext-is-not-implemented
+      };
+
       // WHEN initial render
       const { result } = renderHook(() => {
         return useSession({


### PR DESCRIPTION
Could be solved in a more a robust/testable way with a vitest-flavored implementation of `jest-canvas-mock` (which at present does not exist)

from: https://stackoverflow.com/questions/48828759/unit-test-raises-error-because-of-getcontext-is-not-implemented

## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

-

## 🌄 Context

<!-- Provide more context around why this pull request was created -->

## 🔒Checklist

- I tested my work on the feature environment

## 💅 Examples

<!-- Give examples or screenshots detailing the new behaviors of the application -->
