### PR TITLE
fix: index card drag and drop types

### DIFF
--- a/lib/components/IndexCard/IndexCard.tsx
+++ b/lib/components/IndexCard/IndexCard.tsx
@@ -597,7 +597,7 @@ export const IndexCard: React.FC<
               <BetterDnd
                 direction="vertical"
                 id={block.id}
-                type={`${DragAndDropTypes.SceneIndexCardsBlocks}.${indexCardManager.state.indexCard.id}`}
+                type={`${DragAndDropTypes.SceneIndexCardsBlocks}.${props.parentIndexCard?.id}`}
                 onMove={(dragId, hoverId) => {
                   indexCardManager.actions.moveIndexCardBlock(dragId, hoverId);
                 }}

--- a/lib/components/IndexCard/hooks/useIndexCard.tsx
+++ b/lib/components/IndexCard/hooks/useIndexCard.tsx
@@ -175,10 +175,12 @@ export function useIndexCard(props: {
         const dragIndex = draft.subCards.findIndex((c) => c.id === dragId);
         const hoverIndex = draft.subCards.findIndex((c) => c.id === hoverId);
 
-        const dragItem = draft.subCards[dragIndex];
+        if (dragIndex !== -1 && hoverIndex !== -1) {
+          const dragItem = draft.subCards[dragIndex];
 
-        draft.subCards.splice(dragIndex, 1);
-        draft.subCards.splice(hoverIndex, 0, dragItem);
+          draft.subCards.splice(dragIndex, 1);
+          draft.subCards.splice(hoverIndex, 0, dragItem);
+        }
       })
     );
   }

--- a/lib/hooks/useScene/useScene.ts
+++ b/lib/hooks/useScene/useScene.ts
@@ -284,10 +284,11 @@ export function useScene() {
         const dragIndex = cards.findIndex((c) => c.id === dragId);
         const hoverIndex = cards.findIndex((c) => c.id === hoverId);
 
-        const dragItem = cards[dragIndex];
-
-        cards.splice(dragIndex, 1);
-        cards.splice(hoverIndex, 0, dragItem);
+        if (dragIndex !== -1 && hoverIndex !== -1) {
+          const dragItem = cards[dragIndex];
+          cards.splice(dragIndex, 1);
+          cards.splice(hoverIndex, 0, dragItem);
+        }
       })
     );
   }


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- fix: #407

## 🌄 Context

The Drag and Drop context needs an id to know where things can be dropped or not. In this case, when an index card was rendering the DnD context for sub cards it was using the id of the current card instead of the parent one.

I also added a check in the controllers to make sure to only move the cards if a card is found in the current array.

<!-- Provide more context around why this pull request was created -->
