### PR TITLE
fix: tab switching draw issue where data is not initialized

### DIFF
--- a/lib/routes/Draw/TldrawWriterAndReader.tsx
+++ b/lib/routes/Draw/TldrawWriterAndReader.tsx
@@ -53,6 +53,7 @@ export function TldrawWriter(props: {
 
   function handleTldrawMount(app: TldrawApp) {
     if (props.state.shapes && props.state.bindings) {
+      handleTldrawChange(app, props.state.shapes, props.state.bindings);
       app?.replacePageContent(props.state.shapes, props.state.bindings, {});
     }
   }

--- a/lib/routes/Draw/TldrawWriterAndReader.tsx
+++ b/lib/routes/Draw/TldrawWriterAndReader.tsx
@@ -112,6 +112,7 @@ export function TldrawReader(props: { state: IDrawingAreaState }) {
         setApp(app);
       }}
       showPages={false}
+      showMenu={false}
       readOnly
     />
   );


### PR DESCRIPTION
## ✅ Changes

- fix: tab switching draw issue where data is not initialized
- fix: also hide the menu in readonly tldraw

## 🌄 Context

Adding this line fixes the issue where the drawing is missing when you switch tab. The issue is that when you mount the drawing component, your shapeRef and bindingRef is not initialized with the old data 

## 🔒Checklist

- I tested my work on the feature environment [x]
