### PR TITLE
Bug fix for Subcard

### DIFF
--- a/lib/components/IndexCard/IndexCard.tsx
+++ b/lib/components/IndexCard/IndexCard.tsx
@@ -449,6 +449,7 @@ export const IndexCard: React.FC<
                                       indexCardManager.state.indexCard.id
                                     );
                                   } else {
+                                    indexCardManager.state.indexCard.sub = true;
                                     props.onMoveTo?.(
                                       indexCardManager.state.indexCard.id,
                                       e.target.value as string

--- a/lib/components/IndexCard/IndexCard.tsx
+++ b/lib/components/IndexCard/IndexCard.tsx
@@ -444,6 +444,7 @@ export const IndexCard: React.FC<
                                 renderProps.handleOnClose();
                                 if (e.target.value) {
                                   if (e.target.value === "move-out") {
+                                    indexCardManager.state.indexCard.sub = false;
                                     props.onMoveOut?.(
                                       indexCardManager.state.indexCard.id
                                     );


### PR DESCRIPTION
Fix for: 
https://fari.app/bugs/p/promoted-subcards-have-no-mark-public-button
https://fari.app/bugs/p/cant-move-out-card
https://github.com/fariapp/fari-app/issues/410

## ✅ Changes

Set .sub = false on move out

## 🌄 Context
[
](https://fari.app/bugs/p/promoted-subcards-have-no-mark-public-button)

## 🔒Checklist

tested locally

## 💅 Examples

![image](https://user-images.githubusercontent.com/11036564/188208043-e43b35ce-1b59-4910-9605-b20d3c2fc9bb.png)
