### PR TITLE
fix: cursor scroll position on host

### DIFF
--- a/lib/routes/Play/components/CursorWithMessage/CursorWithMessage.tsx
+++ b/lib/routes/Play/components/CursorWithMessage/CursorWithMessage.tsx
@@ -12,7 +12,7 @@ import { useZIndex } from "../../../../constants/zIndex";
 import { ThemedLabel } from "../../../Character/components/CharacterDialog/components/ThemedLabel";
 import {
   MiniThemeContext,
-  useMiniTheme
+  useMiniTheme,
 } from "../../../Character/components/CharacterDialog/MiniThemeContext";
 import { DefaultPlayerColor } from "../../consts/PlayerColors";
 import { IPlayerCursorRollOutput } from "../../types/IPlayerCursorState";
@@ -122,8 +122,7 @@ export default function CursorWithMessage(props: {
           position: "absolute",
           opacity: stale ? 0.15 : 1,
           pointerEvents: "none",
-          top: "-40px",
-          left: "-10px",
+
           zIndex: zIndex.cursor,
         })}
         style={{
@@ -168,8 +167,8 @@ export default function CursorWithMessage(props: {
       <div
         className={css({
           position: "absolute",
-          top: "2rem",
-          left: "1.5rem",
+          top: "0rem",
+          left: "3rem",
           padding: "1rem",
         })}
         style={{ backgroundColor: color, borderRadius: 4 }}

--- a/lib/routes/Play/components/PlayersPresence/PlayersPresence.tsx
+++ b/lib/routes/Play/components/PlayersPresence/PlayersPresence.tsx
@@ -1,4 +1,3 @@
-import { css } from "@emotion/css";
 import { useMyPresence } from "@liveblocks/react";
 import React, {
   useContext,
@@ -90,15 +89,7 @@ export const PlayersPresence = React.forwardRef((props, ref) => {
 
   return (
     <>
-      <div
-        className={css({
-          label: "PlayersPresence",
-          position: "fixed",
-          top: 0,
-          left: 0,
-          zIndex: zIndex.cursor,
-        })}
-      >
+      <div>
         {windowCursors.map((cursor) => {
           return (
             <CursorWithMessage


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- fix: cursor chat box CSS scroll position

## 🌄 Context

<!-- Provide more context around why this pull request was created -->

There was this weird [CSS bug](https://discord.com/channels/797926344893005875/917091152539295774/1020331457404731453) that seemed to cause the chat box to be rendered WAY below the cursor when a user was scrolling. I think this is due to some CSS positioning stacking up. This PR [should fix the issue](https://discord.com/channels/797926344893005875/917091152539295774/1020335114275799171)!

I've also rearranged the position of the cursor/chatbox so that it's a bit more accurate to the real position


![](https://gyazo.com/acaa46e69b3069c40f60bba49c06a647.gif)